### PR TITLE
fix(a11y): minor a11y improvements (#70, #72, #73, #74)

### DIFF
--- a/src/app.module.css
+++ b/src/app.module.css
@@ -1,3 +1,19 @@
+.skipLink {
+  position: absolute;
+  top: -100%;
+  left: 0;
+  padding: var(--space-sm) var(--space-md);
+  background: var(--shade-1);
+  color: var(--color-text);
+  z-index: 200;
+  text-decoration: none;
+  font-weight: 700;
+}
+
+.skipLink:focus-visible {
+  top: 0;
+}
+
 .layout {
   display: flex;
   flex-direction: column;

--- a/src/app.module.css
+++ b/src/app.module.css
@@ -1,3 +1,16 @@
+.keyboardBadge {
+  position: fixed;
+  bottom: var(--space-md);
+  right: var(--space-md);
+  padding: var(--space-xs) var(--space-sm);
+  background: var(--shade-3);
+  color: var(--shade-0);
+  font-family: var(--font-body);
+  font-size: var(--font-size-xs);
+  z-index: 300;
+  pointer-events: none;
+}
+
 .skipLink {
   position: absolute;
   top: -100%;

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -87,12 +87,15 @@ export function App() {
             view.kind === "character-view" ? view.characterId : view.kind
           }
         />
+        <a href="#main-content" className={styles.skipLink}>
+          Skip to main content
+        </a>
         <TopMenu
           title={getMenuTitle()}
           showBack={view.kind !== "character-list"}
           onBack={goToList}
         />
-        <div className={styles.content}>
+        <div id="main-content" className={styles.content}>
           {view.kind === "character-list" && (
             <CharacterList
               characters={characters}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -102,7 +102,7 @@ export function App() {
           showBack={view.kind !== "character-list"}
           onBack={goToList}
         />
-        <div id="main-content" className={styles.content}>
+        <main id="main-content" tabIndex={-1} className={styles.content}>
           {view.kind === "character-list" && (
             <CharacterList
               characters={characters}
@@ -120,7 +120,7 @@ export function App() {
               onCharacterUpdate={handleCharacterUpdate}
             />
           )}
-        </div>
+        </main>
       </div>
     </ScreenFlashProvider>
   );

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -5,6 +5,7 @@ import { CharacterCreation } from "src/components/character-creation";
 import { CharacterList } from "src/components/character-list";
 import { CharacterSheet } from "src/components/character-sheet";
 import { TopMenu } from "src/components/top-menu";
+import { useKeyboardMode } from "src/hooks/use-keyboard-mode";
 import {
   deleteCharacter,
   loadCharacters,
@@ -19,6 +20,7 @@ type AppView =
   | { kind: "character-creation" };
 
 export function App() {
+  const isKeyboardMode = useKeyboardMode();
   const [view, setView] = useState<AppView>({ kind: "character-list" });
   const [characters, setCharacters] = useState<Character[]>(() =>
     loadCharacters(),
@@ -82,6 +84,11 @@ export function App() {
   return (
     <ScreenFlashProvider>
       <div className={styles.layout}>
+        {isKeyboardMode && (
+          <div aria-hidden className={styles.keyboardBadge}>
+            ⌨ KB NAV
+          </div>
+        )}
         <ScreenFlash
           trigger={
             view.kind === "character-view" ? view.characterId : view.kind

--- a/src/components/character-sheet/hp-tracker/hp-tracker.module.css
+++ b/src/components/character-sheet/hp-tracker/hp-tracker.module.css
@@ -85,3 +85,14 @@
   line-height: 1.6;
   margin: var(--space-sm) 0 0;
 }
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/components/character-sheet/hp-tracker/hp-tracker.test.tsx
+++ b/src/components/character-sheet/hp-tracker/hp-tracker.test.tsx
@@ -13,15 +13,65 @@ describe("<HpTracker />", () => {
         onCurrentChange={vi.fn()}
       />,
     );
-    expect(screen.getByRole("button", { name: "-" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "+" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Decrease HP" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Increase HP" }),
+    ).toBeInTheDocument();
   });
 
   it("renders without buttons in creation mode", () => {
     render(<HpTracker mode="creation" max={12} />);
-    expect(screen.queryByRole("button", { name: "-" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "+" })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Decrease HP" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Increase HP" }),
+    ).not.toBeInTheDocument();
     expect(screen.getByText("12")).toBeInTheDocument();
     expect(screen.getByText("HP")).toBeInTheDocument();
+  });
+
+  it("announces current HP and status via aria-live region", () => {
+    render(
+      <HpTracker
+        mode="sheet"
+        current={15}
+        max={20}
+        editable={false}
+        onCurrentChange={vi.fn()}
+      />,
+    );
+    const status = screen.getByRole("status");
+    expect(status).toHaveTextContent("15 / 20 HP — Healthy");
+  });
+
+  it("announces Wounded status when HP is between 25% and 50%", () => {
+    render(
+      <HpTracker
+        mode="sheet"
+        current={6}
+        max={20}
+        editable={false}
+        onCurrentChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("status")).toHaveTextContent("6 / 20 HP — Wounded");
+  });
+
+  it("announces Critical status when HP is at or below 25%", () => {
+    render(
+      <HpTracker
+        mode="sheet"
+        current={2}
+        max={20}
+        editable={false}
+        onCurrentChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "2 / 20 HP — Critical",
+    );
   });
 });

--- a/src/components/character-sheet/hp-tracker/hp-tracker.tsx
+++ b/src/components/character-sheet/hp-tracker/hp-tracker.tsx
@@ -100,6 +100,7 @@ export function HpTracker(props: HpTrackerProps) {
               type="number"
               min={0}
               value={current}
+              aria-label="Current HP"
               onChange={(e) => {
                 const parsed = Number.parseInt(e.target.value, 10);
                 if (!Number.isNaN(parsed)) onCurrentChange(parsed);
@@ -115,6 +116,7 @@ export function HpTracker(props: HpTrackerProps) {
               type="number"
               min={1}
               value={max}
+              aria-label="Max HP"
               onChange={(e) => {
                 const parsed = Number.parseInt(e.target.value, 10);
                 if (!Number.isNaN(parsed)) onMaxChange?.(parsed);

--- a/src/components/character-sheet/hp-tracker/hp-tracker.tsx
+++ b/src/components/character-sheet/hp-tracker/hp-tracker.tsx
@@ -25,6 +25,12 @@ function blockColor(ratio: number, dynamicColor: boolean): string {
   return "var(--color-hp-low)";
 }
 
+function healthStatus(ratio: number): "Healthy" | "Wounded" | "Critical" {
+  if (ratio > 0.5) return "Healthy";
+  if (ratio > 0.25) return "Wounded";
+  return "Critical";
+}
+
 function HpBar({
   current,
   max,
@@ -68,14 +74,20 @@ export function HpTracker(props: HpTrackerProps) {
   }
 
   const { current, max, editable, onCurrentChange, onMaxChange } = props;
+  const ratio = max > 0 ? current / max : 0;
 
   return (
     <Section title="Hit Points">
       <HpBar current={current} max={max} dynamicColor />
 
       <div className={styles.controls}>
+        <span role="status" className={styles.srOnly}>
+          {current} / {max} HP — {healthStatus(ratio)}
+        </span>
+
         <button
           type="button"
+          aria-label="Decrease HP"
           onClick={() => onCurrentChange(Math.max(0, current - 1))}
           className={styles.button}
         >
@@ -116,6 +128,7 @@ export function HpTracker(props: HpTrackerProps) {
 
         <button
           type="button"
+          aria-label="Increase HP"
           onClick={() => onCurrentChange(Math.min(max, current + 1))}
           className={styles.button}
         >

--- a/src/components/character-sheet/hp-tracker/hp-tracker.tsx
+++ b/src/components/character-sheet/hp-tracker/hp-tracker.tsx
@@ -81,9 +81,9 @@ export function HpTracker(props: HpTrackerProps) {
       <HpBar current={current} max={max} dynamicColor />
 
       <div className={styles.controls}>
-        <span role="status" className={styles.srOnly}>
+        <output className={styles.srOnly}>
           {current} / {max} HP — {healthStatus(ratio)}
-        </span>
+        </output>
 
         <button
           type="button"

--- a/src/components/character-sheet/spell-book/spell-book.test.tsx
+++ b/src/components/character-sheet/spell-book/spell-book.test.tsx
@@ -200,6 +200,35 @@ describe("<SpellBook />", () => {
     expect(onSpellsChange).toHaveBeenCalledWith([cantrip]);
   });
 
+  it("staged spell in grid has aria-label with 'preparing' and aria-pressed", () => {
+    const cantrip = createSpell({
+      id: "c-1",
+      name: "Cantrip 1",
+      level: 0,
+      description: "Description 1",
+    });
+
+    render(
+      <SpellBook
+        availableCantrips={[cantrip]}
+        availableLevel1={[]}
+        selectedSpells={[]}
+        cantripLimit={3}
+        level1Limit={0}
+        onSpellsChange={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Prepare Cantrips/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Cantrip 1/i }));
+
+    const gridBtn = within(
+      screen.getByRole("region", { name: "Prepare Spells" }),
+    ).getByRole("button", { name: /Cantrip 1/i });
+    expect(gridBtn).toHaveAttribute("aria-label", "Cantrip 1, preparing");
+    expect(gridBtn).toHaveAttribute("aria-pressed", "true");
+  });
+
   it("removes staged spell when clicked in spell book", () => {
     const cantrip = createSpell({
       id: "c-1",

--- a/src/components/character-sheet/spell-book/spell-book.tsx
+++ b/src/components/character-sheet/spell-book/spell-book.tsx
@@ -231,7 +231,8 @@ function SpellSelectionGrid({
                   else buttonRefs.current.delete(spell.id);
                 }}
                 type="button"
-                aria-label={spell.name}
+                aria-label={`${spell.name}${isCommitted ? ", prepared" : isStaged ? ", preparing" : ""}`}
+                aria-pressed={isCommitted || isStaged}
                 aria-expanded={isExpanded}
                 disabled={isDisabled}
                 className={c(

--- a/src/components/character-sheet/spell-cards/spell-cards.test.tsx
+++ b/src/components/character-sheet/spell-cards/spell-cards.test.tsx
@@ -1,27 +1,53 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { SpellCards } from "./spell-cards";
+
+import type { Spell } from "src/models/spells/spells";
+
+const fireBolt: Spell = {
+  id: "fire-bolt",
+  name: "Fire Bolt",
+  level: 0,
+  school: "Evocation",
+  castingTime: "1 action",
+  range: "120 feet",
+  components: "V, S",
+  duration: "Instantaneous",
+  description: "A beam of fire",
+  damage: { dice: "1d10", type: "fire" },
+};
 
 describe("<SpellCards />", () => {
   it("renders the Spells section", () => {
+    render(<SpellCards spells={[fireBolt]} />);
+    expect(screen.getByRole("region", { name: "Spells" })).toBeInTheDocument();
+  });
+
+  it("staged spell has aria-label indicating 'preparing'", () => {
     render(
       <SpellCards
-        spells={[
-          {
-            id: "fire-bolt",
-            name: "Fire Bolt",
-            level: 0,
-            school: "Evocation",
-            castingTime: "1 action",
-            range: "120 feet",
-            components: "V, S",
-            duration: "Instantaneous",
-            description: "A beam of fire",
-            damage: { dice: "1d10", type: "fire" },
-          },
-        ]}
+        spells={[fireBolt]}
+        stagedSpellIds={["fire-bolt"]}
+        onStagedSpellClick={vi.fn()}
       />,
     );
-    expect(screen.getByRole("region", { name: "Spells" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "Fire Bolt, preparing — click to remove",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("non-staged spell has aria-label indicating 'prepared' when in SpellBook context", () => {
+    render(
+      <SpellCards
+        spells={[fireBolt]}
+        stagedSpellIds={[]}
+        onStagedSpellClick={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Fire Bolt, prepared" }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/character-sheet/spell-cards/spell-cards.tsx
+++ b/src/components/character-sheet/spell-cards/spell-cards.tsx
@@ -27,6 +27,7 @@ export function SpellCards({
   const { expandedKey: expandedSpell, toggle: toggleSpell } =
     useExpandable<string>();
   const stagedIds = new Set(stagedSpellIds);
+  const showPreparationState = !!onStagedSpellClick;
 
   const cantrips = spells.filter((s) => s.level === 0);
   const levelSpells = spells.filter((s) => s.level > 0);
@@ -56,6 +57,7 @@ export function SpellCards({
                 key={spell.name}
                 spell={spell}
                 isStaged={stagedIds.has(spell.id)}
+                showPreparationState={showPreparationState}
                 isExpanded={expandedSpell === spell.name}
                 onToggle={() => {
                   if (stagedIds.has(spell.id)) {
@@ -85,6 +87,7 @@ export function SpellCards({
                 key={spell.name}
                 spell={spell}
                 isStaged={stagedIds.has(spell.id)}
+                showPreparationState={showPreparationState}
                 isExpanded={expandedSpell === spell.name}
                 onToggle={() => {
                   if (stagedIds.has(spell.id)) {
@@ -117,19 +120,32 @@ export function SpellCards({
 type SpellCardProps = {
   spell: Spell;
   isStaged: boolean;
+  showPreparationState?: boolean;
   isExpanded: boolean;
   onToggle: () => void;
 };
 
-function SpellCard({ spell, isStaged, isExpanded, onToggle }: SpellCardProps) {
+function SpellCard({
+  spell,
+  isStaged,
+  showPreparationState = false,
+  isExpanded,
+  onToggle,
+}: SpellCardProps) {
   const simplifiedComponents = simplifyComponents(spell.components);
   const formattedDescription = formatDescription(spell.description);
   const spellResult = formatSpellResult(spell);
   const resultColor = spell.damage ? DAMAGE_COLOR : undefined;
+  const accessibleLabel = isStaged
+    ? `${spell.name}, preparing — click to remove`
+    : showPreparationState
+      ? `${spell.name}, prepared`
+      : spell.name;
 
   return (
     <button
       type="button"
+      aria-label={accessibleLabel}
       onClick={onToggle}
       className={`${styles.card} ${isStaged ? styles.cardStaged : ""}`}
     >

--- a/src/components/character-sheet/spell-cards/spell-cards.tsx
+++ b/src/components/character-sheet/spell-cards/spell-cards.tsx
@@ -146,6 +146,7 @@ function SpellCard({
     <button
       type="button"
       aria-label={accessibleLabel}
+      aria-expanded={isExpanded}
       onClick={onToggle}
       className={`${styles.card} ${isStaged ? styles.cardStaged : ""}`}
     >

--- a/src/hooks/use-keyboard-mode.test.ts
+++ b/src/hooks/use-keyboard-mode.test.ts
@@ -1,0 +1,55 @@
+import { act, renderHook } from "@testing-library/react";
+import { useKeyboardMode } from "src/hooks/use-keyboard-mode";
+
+describe("useKeyboardMode()", () => {
+  it("returns false initially", () => {
+    const { result } = renderHook(() => useKeyboardMode());
+    expect(result.current).toBe(false);
+  });
+
+  it("returns true after Tab keydown", () => {
+    const { result } = renderHook(() => useKeyboardMode());
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab" }));
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("ignores non-Tab keydown", () => {
+    const { result } = renderHook(() => useKeyboardMode());
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("returns false after pointerdown", () => {
+    const { result } = renderHook(() => useKeyboardMode());
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab" }));
+    });
+    expect(result.current).toBe(true);
+
+    act(() => {
+      document.dispatchEvent(new PointerEvent("pointerdown"));
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it("removes event listeners on unmount", () => {
+    const { result, unmount } = renderHook(() => useKeyboardMode());
+
+    unmount();
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab" }));
+    });
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/hooks/use-keyboard-mode.ts
+++ b/src/hooks/use-keyboard-mode.ts
@@ -4,16 +4,19 @@ export function useKeyboardMode(): boolean {
   const [isKeyboardMode, setIsKeyboardMode] = useState(false);
 
   useEffect(() => {
+    let isActive = true;
+
     function onKeyDown(e: KeyboardEvent) {
-      if (e.key === "Tab") setIsKeyboardMode(true);
+      if (isActive && e.key === "Tab") setIsKeyboardMode(true);
     }
     function onPointerDown() {
-      setIsKeyboardMode(false);
+      if (isActive) setIsKeyboardMode(false);
     }
 
     document.addEventListener("keydown", onKeyDown);
     document.addEventListener("pointerdown", onPointerDown);
     return () => {
+      isActive = false;
       document.removeEventListener("keydown", onKeyDown);
       document.removeEventListener("pointerdown", onPointerDown);
     };

--- a/src/hooks/use-keyboard-mode.ts
+++ b/src/hooks/use-keyboard-mode.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+
+export function useKeyboardMode(): boolean {
+  const [isKeyboardMode, setIsKeyboardMode] = useState(false);
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Tab") setIsKeyboardMode(true);
+    }
+    function onPointerDown() {
+      setIsKeyboardMode(false);
+    }
+
+    document.addEventListener("keydown", onKeyDown);
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("pointerdown", onPointerDown);
+    };
+  }, []);
+
+  return isKeyboardMode;
+}


### PR DESCRIPTION
## Summary

- **#70** HpTracker: `role="status"` live region announces HP value + Healthy/Wounded/Critical on every change; `aria-label` added to +/- buttons
- **#72** Skip link added before TopMenu so keyboard users can jump directly to `#main-content`
- **#73** SpellBook/SpellCards: spell buttons now carry state text — `", prepared"` (committed) or `", preparing — click to remove"` (staged); `aria-pressed` added to SpellSelectionGrid
- **#74** `useKeyboardMode` hook detects Tab navigation; `⌨ KB NAV` badge appears (fixed, bottom-right, `aria-hidden`) and disappears on pointer input

> Note: #71 (ResourceChip aria-live) was researched and an implementation plan was posted as a comment on the issue — skipped for this branch after finding per-button live regions are an anti-pattern; needs a container-level announcement in ResourceTracker.

## Test plan

- [ ] `pnpm test` — all 292 tests pass
- [ ] Tab through the sheet — KB NAV badge appears; click anywhere — badge disappears
- [ ] Tab to skip link — "Skip to main content" appears; Enter jumps focus past TopMenu
- [ ] Stage a spell — screen reader announces "Cantrip Name, preparing"; commit — announces "prepared"
- [ ] Change HP via buttons — screen reader announces "X / Y HP — Healthy/Wounded/Critical"

🤖 Generated with [Claude Code](https://claude.com/claude-code)